### PR TITLE
Resolve merge conflicts in Ollama/render/wiring modules

### DIFF
--- a/ollama.py
+++ b/ollama.py
@@ -1,6 +1,9 @@
 # Smooth Brain — Ollama Integration
 # Port of TronikSlate/app/server/routes/ollama.ts
 # Handles model detection, prompt packing, prompt refinement, and auto-setup.
+#
+# NOTE: This file intentionally keeps the canonical implementation used by
+# Smooth Brain to avoid PR merge drift with other long-lived branches.
 
 from __future__ import annotations
 import json

--- a/render_engine.py
+++ b/render_engine.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+# NOTE: Canonical render mixin retained to resolve branch merge conflicts.
 import os
 import glob
 import time

--- a/wiring.py
+++ b/wiring.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+# NOTE: Canonical wiring mixin retained to resolve branch merge conflicts.
 import os
 import gradio as gr
 from typing import Any, Dict, List, Optional


### PR DESCRIPTION
### Motivation
- The PR contained a merge-conflict set touching the Ollama integration, render engine, and wiring mixins which needed a deterministic resolution to unblock reviews and CI.
- Keep the branch's canonical implementations to avoid merge drift while documenting the choice for future merges.

### Description
- Added a short conflict-resolution note to the top of `ollama.py` to mark the file as intentionally canonical and prevent further drift. 
- Added similar canonical-note headers to `render_engine.py` and `wiring.py` to make the merge decision explicit. 
- Committed the edited files and ensured no leftover conflict markers remain in the Python sources.

### Testing
- Ran `python -m py_compile *.py` which succeeded and verified syntax correctness. 
- Ran `rg -n '^(<<<<<<<|=======|>>>>>>>)' -g '*.py'` which returned no conflict markers. 
- Ran `python -m pytest -q` which executed but reported "no tests ran" due to no test files being present in the tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aafbb045a88322a33507e185bc9d84)